### PR TITLE
useReducer over useState

### DIFF
--- a/src/exercise/01.js
+++ b/src/exercise/01.js
@@ -3,10 +3,14 @@
 
 import * as React from 'react'
 
+function countReducer(state, newState) {
+  return newState
+}
+
 function Counter({initialCount = 0, step = 1}) {
   // 🐨 replace React.useState with React.useReducer.
   // 💰 React.useReducer(countReducer, initialCount)
-  const [count, setCount] = React.useState(initialCount)
+  const [count, setCount] = React.useReducer(countReducer, initialCount)
 
   // 💰 you can write the countReducer function so you don't have to make any
   // changes to the next two lines of code! Remember:

--- a/src/exercise/01.js
+++ b/src/exercise/01.js
@@ -4,13 +4,15 @@
 import * as React from 'react'
 
 function countReducer(state, newState) {
-  return state + newState
+  return {count: newState.count}
 }
 
 function Counter({initialCount = 0, step = 1}) {
-  const [count, setCount] = React.useReducer(countReducer, initialCount)
-
-  const increment = () => setCount(step)
+  const [state, setState] = React.useReducer(countReducer, {
+    count: initialCount,
+  })
+  const {count} = state
+  const increment = () => setState({count: count + step})
   return <button onClick={increment}>{count}</button>
 }
 

--- a/src/exercise/01.js
+++ b/src/exercise/01.js
@@ -4,19 +4,13 @@
 import * as React from 'react'
 
 function countReducer(state, newState) {
-  return newState
+  return state + newState
 }
 
 function Counter({initialCount = 0, step = 1}) {
-  // 🐨 replace React.useState with React.useReducer.
-  // 💰 React.useReducer(countReducer, initialCount)
   const [count, setCount] = React.useReducer(countReducer, initialCount)
 
-  // 💰 you can write the countReducer function so you don't have to make any
-  // changes to the next two lines of code! Remember:
-  // The 1st argument is called "state" - the current value of count
-  // The 2nd argument is called "newState" - the value passed to setCount
-  const increment = () => setCount(count + step)
+  const increment = () => setCount(step)
   return <button onClick={increment}>{count}</button>
 }
 

--- a/src/exercise/01.js
+++ b/src/exercise/01.js
@@ -4,7 +4,7 @@
 import * as React from 'react'
 
 function countReducer(state, newState) {
-  return {count: newState.count}
+  return newState(state)
 }
 
 function Counter({initialCount = 0, step = 1}) {
@@ -12,7 +12,8 @@ function Counter({initialCount = 0, step = 1}) {
     count: initialCount,
   })
   const {count} = state
-  const increment = () => setState({count: count + step})
+  const increment = () =>
+    setState(currentState => ({count: currentState.count + step}))
   return <button onClick={increment}>{count}</button>
 }
 

--- a/src/exercise/01.js
+++ b/src/exercise/01.js
@@ -4,16 +4,20 @@
 import * as React from 'react'
 
 function countReducer(state, newState) {
-  return newState(state)
+  switch (newState.type) {
+    case 'INCREMENT':
+      return {count: state.count + newState.step}
+    default:
+      return state
+  }
 }
 
 function Counter({initialCount = 0, step = 1}) {
-  const [state, setState] = React.useReducer(countReducer, {
+  const [state, dispatch] = React.useReducer(countReducer, {
     count: initialCount,
   })
   const {count} = state
-  const increment = () =>
-    setState(currentState => ({count: currentState.count + step}))
+  const increment = () => dispatch({type: 'INCREMENT', step})
   return <button onClick={increment}>{count}</button>
 }
 

--- a/src/exercise/01.md
+++ b/src/exercise/01.md
@@ -4,6 +4,15 @@
 
 Elaborate on your learnings here in `src/exercise/01.md`
 
+- `React.useReducer` seems to be a powerful version of `React.useState` where we
+  actually get to specify the function that can act on the current state and
+  then arrive at the new state, instead of `setState` being independent of the
+  current state.
+- `React.useReducer` also allows us to do lazy initialization for the state by
+  passing a third init function argument -> this way, if state needs to
+  initialized via costly operations, it can be done only once and not on all
+  re-renders.
+
 ## Background
 
 React's `useState` hook can get you a really long way with React state


### PR DESCRIPTION
- `React.useReducer` seems to be a powerful version of `React.useState` where we actually get to specify the function that can act on the current state and then arrive at the new state, instead of `setState` being independent of the current state.
- `React.useReducer` also allows us to do lazy initialization for the state by passing a third `init` function argument -> this way, if state needs to  initialized via costly operations, it can be done only once and not on all re-renders.