### PR TITLE
Learning `React.useContext`

### DIFF
--- a/src/exercise/03.extra-2.js
+++ b/src/exercise/03.extra-2.js
@@ -2,9 +2,6 @@
 // 💯 caching in a context provider (exercise)
 // http://localhost:3000/isolated/exercise/03.extra-2.js
 
-// you can edit this here and look at the isolated page or you can copy/paste
-// this in the regular exercise file.
-
 import * as React from 'react'
 import {
   fetchPokemon,
@@ -15,14 +12,7 @@ import {
 } from '../pokemon'
 import {useAsync} from '../utils'
 
-// 🐨 Create a PokemonCacheContext
-
-// 🐨 create a PokemonCacheProvider function
-// 🐨 useReducer with pokemonCacheReducer in your PokemonCacheProvider
-// 💰 you can grab the one that's in PokemonInfo
-// 🐨 return your context provider with the value assigned to what you get back from useReducer
-// 💰 value={[cache, dispatch]}
-// 💰 make sure you forward the props.children!
+const PokemonCacheContext = React.createContext()
 
 function pokemonCacheReducer(state, action) {
   switch (action.type) {
@@ -35,11 +25,20 @@ function pokemonCacheReducer(state, action) {
   }
 }
 
-function PokemonInfo({pokemonName}) {
-  // 💣 remove the useReducer here (or move it up to your PokemonCacheProvider)
-  const [cache, dispatch] = React.useReducer(pokemonCacheReducer, {})
-  // 🐨 get the cache and dispatch from useContext with PokemonCacheContext
+function PokemonCacheProvider(props) {
+  const value = React.useReducer(pokemonCacheReducer, {})
+  return <PokemonCacheContext.Provider value={value} {...props} />
+}
 
+function usePokemonCache() {
+  const context = React.useContext(PokemonCacheContext)
+  if (!context)
+    throw new Error('usePokemonCache() cannot be used out of context.')
+  return context
+}
+
+function PokemonInfo({pokemonName}) {
+  const [cache, dispatch] = usePokemonCache()
   const {data: pokemon, status, error, run, setData} = useAsync()
 
   React.useEffect(() => {
@@ -55,7 +54,7 @@ function PokemonInfo({pokemonName}) {
         }),
       )
     }
-  }, [cache, pokemonName, run, setData])
+  }, [cache, pokemonName, run, setData, dispatch])
 
   if (status === 'idle') {
     return 'Submit a pokemon'
@@ -69,8 +68,7 @@ function PokemonInfo({pokemonName}) {
 }
 
 function PreviousPokemon({onSelect}) {
-  // 🐨 get the cache from useContext with PokemonCacheContext
-  const cache = {}
+  const [cache] = usePokemonCache()
   return (
     <div>
       Previous Pokemon
@@ -91,19 +89,19 @@ function PreviousPokemon({onSelect}) {
 }
 
 function PokemonSection({onSelect, pokemonName}) {
-  // 🐨 wrap this in the PokemonCacheProvider so the PreviousPokemon
-  // and PokemonInfo components have access to that context.
   return (
     <div style={{display: 'flex'}}>
-      <PreviousPokemon onSelect={onSelect} />
-      <div className="pokemon-info" style={{marginLeft: 10}}>
-        <PokemonErrorBoundary
-          onReset={() => onSelect('')}
-          resetKeys={[pokemonName]}
-        >
-          <PokemonInfo pokemonName={pokemonName} />
-        </PokemonErrorBoundary>
-      </div>
+      <PokemonCacheProvider>
+        <PreviousPokemon onSelect={onSelect} />
+        <div className="pokemon-info" style={{marginLeft: 10}}>
+          <PokemonErrorBoundary
+            onReset={() => onSelect('')}
+            resetKeys={[pokemonName]}
+          >
+            <PokemonInfo pokemonName={pokemonName} />
+          </PokemonErrorBoundary>
+        </div>
+      </PokemonCacheProvider>
     </div>
   )
 }

--- a/src/exercise/03.js
+++ b/src/exercise/03.js
@@ -6,20 +6,24 @@ import * as React from 'react'
 const CountContext = React.createContext()
 
 function CountProvider(props) {
-  console.log('count provider')
   const value = React.useState(0)
   return <CountContext.Provider value={value} {...props} />
 }
 
+function useCount() {
+  const context = React.useContext(CountContext)
+  if (!context)
+    throw new Error('useCount must be used with CountProvider context.')
+  return context
+}
+
 function CountDisplay() {
-  console.log('count display')
-  const [count] = React.useContext(CountContext)
+  const [count] = useCount()
   return <div>{`The current count is ${count}`}</div>
 }
 
 function Counter() {
-  console.log('counter')
-  const [, setCount] = React.useContext(CountContext)
+  const [, setCount] = useCount()
   const increment = () => setCount(c => c + 1)
   return <button onClick={increment}>Increment count</button>
 }

--- a/src/exercise/03.js
+++ b/src/exercise/03.js
@@ -3,23 +3,23 @@
 
 import * as React from 'react'
 
-// 🐨 create your CountContext here with React.createContext
+const CountContext = React.createContext()
 
-// 🐨 create a CountProvider component here that does this:
-//   🐨 get the count state and setCount updater with React.useState
-//   🐨 create a `value` array with count and setCount
-//   🐨 return your context provider with the value assigned to that array and forward all the other props
-//   💰 more specifically, we need the children prop forwarded to the context provider
+function CountProvider(props) {
+  console.log('count provider')
+  const value = React.useState(0)
+  return <CountContext.Provider value={value} {...props} />
+}
 
 function CountDisplay() {
-  // 🐨 get the count from useContext with the CountContext
-  const count = 0
+  console.log('count display')
+  const [count] = React.useContext(CountContext)
   return <div>{`The current count is ${count}`}</div>
 }
 
 function Counter() {
-  // 🐨 get the setCount from useContext with the CountContext
-  const setCount = () => {}
+  console.log('counter')
+  const [, setCount] = React.useContext(CountContext)
   const increment = () => setCount(c => c + 1)
   return <button onClick={increment}>Increment count</button>
 }
@@ -27,12 +27,10 @@ function Counter() {
 function App() {
   return (
     <div>
-      {/*
-        🐨 wrap these two components in the CountProvider so they can access
-        the CountContext value
-      */}
-      <CountDisplay />
-      <Counter />
+      <CountProvider>
+        <CountDisplay />
+        <Counter />
+      </CountProvider>
     </div>
   )
 }

--- a/src/exercise/03.md
+++ b/src/exercise/03.md
@@ -4,13 +4,24 @@
 
 Elaborate on your learnings here in `src/exercise/03.md`
 
+- `createContext`, `useContext` hooks are useful to store a state in one global
+  place and share it between all components on that same tree. This needs to be
+  used rarely though, more when we are building a library or so.
+- `prop drilling` is what happens when we are passing down a `prop` through
+  several components, simply because the leaf node will need to use it. This can
+  be avoided using prop composition.
+- `prop composition` is basically using the `children` prop to destructure in a
+  way that state can directly be passed to the component using it, and not
+  through `prop drilling`.
+
 ## Background
 
 Sharing state between components is a common problem. The best solution for this
-is to 📜 [lift your state](https://react.dev/learn/sharing-state-between-components). This
-requires 📜 [prop drilling](https://kentcdodds.com/blog/prop-drilling) which is
-not a problem, but there are some times where prop drilling can cause a real
-pain.
+is to 📜
+[lift your state](https://react.dev/learn/sharing-state-between-components).
+This requires 📜 [prop drilling](https://kentcdodds.com/blog/prop-drilling)
+which is not a problem, but there are some times where prop drilling can cause a
+real pain.
 
 To avoid this pain, we can insert some state into a section of our react tree,
 and then extract that state anywhere within that react tree without having to
@@ -121,8 +132,8 @@ function App() {
 }
 ```
 
-It should throw an error indicating that `useCount` may only be used from within a (child of a)
-CountProvider.
+It should throw an error indicating that `useCount` may only be used from within
+a (child of a) CountProvider.
 
 ### 2. 💯 caching in a context provider
 

--- a/src/exercise/03.md
+++ b/src/exercise/03.md
@@ -13,6 +13,9 @@ Elaborate on your learnings here in `src/exercise/03.md`
 - `prop composition` is basically using the `children` prop to destructure in a
   way that state can directly be passed to the component using it, and not
   through `prop drilling`.
+- We can handle the error of not correctly invoking the functions using a given
+  context at one place by creating custom `useContext` hooks, like the
+  `useCount` example in this exercise.
 
 ## Background
 


### PR DESCRIPTION
- `createContext`, `useContext` hooks are useful to store a state in one global place and share it between all components on that same tree. This needs to be used rarely though, more when we are building a library or so.
- `prop drilling` is what happens when we are passing down a `prop` through several components, simply because the leaf node will need to use it. This can be avoided using prop composition.
- `prop composition` is basically using the `children` prop to de-structure in a way that state can directly be passed to the component using it, and not through `prop drilling`.
- We can handle the error of not correctly invoking the functions using a given context at one place by creating custom `useContext` hooks, like the `useCount` example in this exercise.