### PR TITLE
`useLayoutEffect` vs `useEffect`

### DIFF
--- a/src/exercise/04.js
+++ b/src/exercise/04.js
@@ -5,8 +5,7 @@ import * as React from 'react'
 
 function MessagesDisplay({messages}) {
   const containerRef = React.useRef()
-  // 🐨 replace useEffect with useLayoutEffect
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     containerRef.current.scrollTop = containerRef.current.scrollHeight
   })
 

--- a/src/exercise/04.md
+++ b/src/exercise/04.md
@@ -4,6 +4,10 @@
 
 Elaborate on your learnings here in `src/exercise/04.md`
 
+- If we are updating DOM in `useEffect`, it may cause a blip for the user as DOM
+  gets rendered first and then the change will take effect. So in these cases,
+  `useLayoutEffect` can help, because it runs before rendering DOM.
+
 ## Background
 
 There are two ways to tell React to run side-effects after it renders:


### PR DESCRIPTION
If we are updating DOM in `useEffect`, it may cause a blip for the user as DOM gets rendered first and then the change will take effect. So in these cases, `useLayoutEffect` can help, because it runs before rendering DOM.