### PR TITLE
Learning to use `React.useDebugValue`

### DIFF
--- a/src/exercise/06.js
+++ b/src/exercise/06.js
@@ -5,8 +5,8 @@ import * as React from 'react'
 
 function useMedia(query, initialState = false) {
   const [state, setState] = React.useState(initialState)
-  // 🐨 call React.useDebugValue here.
-  // 💰 here's the formatted label I use: `\`${query}\` => ${state}`
+
+  React.useDebugValue(`\`${query}\` => ${state}`)
 
   React.useEffect(() => {
     let mounted = true

--- a/src/exercise/06.js
+++ b/src/exercise/06.js
@@ -3,10 +3,14 @@
 
 import * as React from 'react'
 
+function formatDebugValue({query, state}) {
+  return `\`${query}\` => ${state}`
+}
+
 function useMedia(query, initialState = false) {
   const [state, setState] = React.useState(initialState)
 
-  React.useDebugValue(`\`${query}\` => ${state}`)
+  React.useDebugValue({query, state}, formatDebugValue)
 
   React.useEffect(() => {
     let mounted = true

--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -4,6 +4,11 @@
 
 Elaborate on your learnings here in `src/exercise/06.md`
 
+- `React.useDebugValue` is an easy way to debug react components (it shows up on
+  the components tab of the react dev tools).
+- `React.useDebugValue` automatically doesn't show up on production deploy (only
+  does the writes in dev mode).
+
 ## Background
 
 [The React DevTools browser extension](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en)
@@ -33,7 +38,8 @@ Production deploys:
 - [Exercise](https://advanced-react-hooks.netlify.com/isolated/exercise/06.js)
 - [Final](https://advanced-react-hooks.netlify.com/isolated/final/06.js)
 
-> Note: useDebugValue values will not show in production, because the production build of useDebugValue does nothing.
+> Note: useDebugValue values will not show in production, because the production
+> build of useDebugValue does nothing.
 
 In this exercise, we have a custom `useMedia` hook which uses
 `window.matchMedia` to determine whether the user-agent satisfies a given media

--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -8,6 +8,9 @@ Elaborate on your learnings here in `src/exercise/06.md`
   the components tab of the react dev tools).
 - `React.useDebugValue` automatically doesn't show up on production deploy (only
   does the writes in dev mode).
+- It also allows for a formatter function as a second argument, which is handy
+  when the formatter is a costly computation - because it will only be computed
+  when the dev tools are actually open and not otherwise.
 
 ## Background
 


### PR DESCRIPTION
- `React.useDebugValue` is an easy way to debug react components (it shows up on the components tab of the react dev tools).
- `React.useDebugValue` automatically doesn't show up on production deploy (only does the writes in dev mode).
- It also allows for a formatter function as a second argument, which is handy when the formatter is a costly computation - because it will only be computed when the dev tools are actually open and not otherwise.